### PR TITLE
Added (optional) flagging of changed records

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "OrderingDeck": "The Deck::KLC Important Vocab",
     "SourceDeck": "The Deck::Core 2k/6k Optimized Japanese Vocabulary",
-    "ReloadButtonEnabled": false
+    "ReloadButtonEnabled": false,
+    "Flagging": false
 }


### PR DESCRIPTION
Marks the changed state of records with various colors depending on whether or not a match existed, when a match has replaced the original, and when multiple matches exist and are awaiting match selection.
![image](https://user-images.githubusercontent.com/434942/41519952-fdb25744-727f-11e8-95ed-cdbf3ee4219c.png)
Fun tip- Add `(flag:0 or flag:2)` to your search filters to show only cards which have not yet been checked for a match or are awaiting selection from multiple potential results. This refreshes on each run, allowing you to quickly process large swathes of cards as the completed ones move out of the way.
This feature is disabled by default and can be enabled by setting the `Flagging` key to `true` in the options JSON.